### PR TITLE
Added Static Method to access instance

### DIFF
--- a/src/nu/nerd/nerdmessage/NerdMessage.java
+++ b/src/nu/nerd/nerdmessage/NerdMessage.java
@@ -15,10 +15,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 public class NerdMessage extends JavaPlugin {
 
     List<NMUser> users = new CopyOnWriteArrayList<NMUser>();
+    public static NerdMessage inst;
 
     @Override
     public void onEnable() {
         this.getServer().getPluginManager().registerEvents(new NerdMessageListener(this), this);
+        this.inst = this;
     }
 
     @Override
@@ -135,6 +137,10 @@ public class NerdMessage extends JavaPlugin {
         }
         
         return false;
+    }
+    
+    public static NerdMessage getInst(){
+        return inst;
     }
     
     public Player getPlayer(final String name) {


### PR DESCRIPTION
Static method getInst() returns the instance of the plugin used. Allows
other plugins to access the ignore lists stored here, to prevent sending
messages from ignored players.
