### PR TITLE
Modified the mail notified system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>nu.nerd</groupId>
     <artifactId>nerdmessage</artifactId>
-    <version>1.3.3</version>
+    <version>1.3.4</version>
     <packaging>jar</packaging>
     <name>NerdMessage</name>
     <description>Messaging plugin for Bukkit</description>

--- a/src/nu/nerd/nerdmessage/commands/MailCommands.java
+++ b/src/nu/nerd/nerdmessage/commands/MailCommands.java
@@ -226,6 +226,10 @@ public class MailCommands implements CommandExecutor {
             public void run() {
 
                 List<MailMessage> messages = MailMessage.findUnread(player.getUniqueId());
+                for(MailMessage mail : messages) {
+                    mail.setNotified(true);
+                    MailMessage.flagNotified(player.getUniqueId());
+                }
                 int pages = (messages.size() + perPage - 1) / perPage; //integer division
                 int offset = (page - 1) * perPage;
 

--- a/src/nu/nerd/nerdmessage/commands/MailCommands.java
+++ b/src/nu/nerd/nerdmessage/commands/MailCommands.java
@@ -281,7 +281,7 @@ public class MailCommands implements CommandExecutor {
 
         Integer id;
 
-        if (args[1].equals("")) {
+        if(args.length == 1) {
             sender.sendMessage(ChatColor.RED + "Usage: /mail archive <id>");
             return;
         }

--- a/src/nu/nerd/nerdmessage/mail/MailHandler.java
+++ b/src/nu/nerd/nerdmessage/mail/MailHandler.java
@@ -97,7 +97,6 @@ public class MailHandler implements Listener {
             public void run() {
                 if (MailMessage.findUnnotified(player.getUniqueId()).size() > 0) {
                     notifyNewMessages(player.getUniqueId(), true);
-                    MailMessage.flagNotified(player.getUniqueId());
                 }
             }
         }.runTaskLaterAsynchronously(plugin, 40L);
@@ -112,21 +111,14 @@ public class MailHandler implements Listener {
      * @param isOrigin this is the server the message is originating from
      */
     public void notifyNewMessages(UUID recipient, boolean isOrigin) {
-        boolean notified = false;
         Player player = plugin.getServer().getPlayer(recipient);
         String msg = String.format("%sYou have new mail! Type %s/mail inbox%s to read it.", ChatColor.GREEN, ChatColor.LIGHT_PURPLE, ChatColor.GREEN);
         if (player != null && player.isOnline()) {
             player.sendMessage(msg);
-            notified = true;
         } else {
             if (plugin.crossServerEnabled() && isOrigin) {
                 plugin.redisPublish("mail.new", recipient.toString());
             }
         }
-        if (notified) {
-            MailMessage.flagNotified(recipient);
-        }
     }
-
-
 }


### PR DESCRIPTION
The "You have new mail!" notification is no longer wiped on first join and instead is wiped when the player runs `/mail inbox`, as players tend to miss the one and only notification.

Also fixes #9